### PR TITLE
chore: Drop GraphQL support for GHES 3.9

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -26,5 +26,4 @@ createProject("graphql", "ghes-3.13")
 createProject("graphql", "ghes-3.12")
 createProject("graphql", "ghes-3.11")
 createProject("graphql", "ghes-3.10")
-createProject("graphql", "ghes-3.9")
 


### PR DESCRIPTION
The schema is no longer available.